### PR TITLE
Account for multicasting support when finding capable IPs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,8 @@ bcder = { version = "0.7" , optional = true } # ASN.1 DER encoding
 const-oid = { version = "0.9" , optional = true } # more ASN.1
 openssl = { version = "0.10.70", optional = true }
 cryptoki = { version = "0.8", optional = true }
+pnet = { version = "0.35.0", default-features = false, features = ["std", "pnet_datalink"] }
+pnet_sys = { version = "0.35.0", default-features = false }
 
 
 [target.'cfg(windows)'.dependencies]

--- a/src/discovery/discovery.rs
+++ b/src/discovery/discovery.rs
@@ -135,9 +135,7 @@ mod with_key {
   use mio_extras::timer::Timer;
 
   use super::{DataReaderPlCdr, DataWriterPlCdr};
-  use crate::{
-    polling::TimerPolicy, serialization::pl_cdr_adapters::*, Key, Keyed, Topic, TopicKind,
-  };
+  use crate::{polling::TimerPolicy, serialization::pl_cdr_adapters::*, Key, Keyed, Topic, TopicKind};
 
   pub const TOPIC_KIND: TopicKind = TopicKind::WithKey;
 
@@ -2073,7 +2071,10 @@ mod tests {
   #[test]
   fn discovery_participant_data_test() {
     let poll = Poll::new().unwrap();
-    let mut udp_listener = UDPListener::new_unicast("127.0.0.1", 11000).unwrap();
+    const LISTENER_PORT: u16 = spdp_well_known_unicast_port(12, 0);
+
+    let mut udp_listener =
+      UDPListener::new_unicast("127.0.0.1", LISTENER_PORT).expect("udp listener creation");
     poll
       .register(
         udp_listener.mio_socket(),
@@ -2085,10 +2086,7 @@ mod tests {
 
     // sending participant data to discovery
     let udp_sender = UDPSender::new_with_random_port().expect("failed to create UDPSender");
-    let addresses = vec![SocketAddr::new(
-      "127.0.0.1".parse().unwrap(),
-      spdp_well_known_unicast_port(0, 0),
-    )];
+    let addresses = vec![SocketAddr::new("127.0.0.1".parse().unwrap(), LISTENER_PORT)];
 
     let tdata = spdp_participant_msg_mod(11000);
     let msg_data = tdata
@@ -2137,8 +2135,10 @@ mod tests {
     let _reader =
       subscriber.create_datareader::<ShapeType, CDRDeserializerAdapter<ShapeType>>(&topic, None);
 
-    let poll = Poll::new().unwrap();
-    let mut udp_listener = UDPListener::new_unicast("127.0.0.1", 11001).unwrap();
+    let poll: Poll = Poll::new().unwrap();
+    const LISTENER_PORT: u16 = spdp_well_known_unicast_port(14, 0);
+
+    let mut udp_listener = UDPListener::new_unicast("127.0.0.1", LISTENER_PORT).unwrap();
     poll
       .register(
         udp_listener.mio_socket(),
@@ -2148,14 +2148,13 @@ mod tests {
       )
       .unwrap();
 
-    let udp_sender = UDPSender::new_with_random_port().expect("failed to create UDPSender");
-    let addresses = vec![SocketAddr::new(
-      "127.0.0.1".parse().unwrap(),
-      spdp_well_known_unicast_port(14, 0),
-    )];
+    let udp_sender: UDPSender =
+      UDPSender::new_with_random_port().expect("failed to create UDPSender");
+    let addresses: Vec<SocketAddr> =
+      vec![SocketAddr::new("127.0.0.1".parse().unwrap(), LISTENER_PORT)];
 
-    let mut tdata = spdp_subscription_msg();
-    let mut data;
+    let mut tdata: crate::rtps::Message = spdp_subscription_msg();
+    let mut data: bytes::Bytes;
     for submsg in &mut tdata.submessages {
       match &mut submsg.body {
         SubmessageBody::Writer(WriterSubmessage::Data(d, _)) => {
@@ -2184,18 +2183,18 @@ mod tests {
       }
     }
 
-    let msg_data = tdata
+    let msg_data: Vec<u8> = tdata
       .write_to_vec_with_ctx(Endianness::LittleEndian)
       .expect("Failed to write msg data");
 
     udp_sender.send_to_all(&msg_data, &addresses);
 
-    let mut events = Events::with_capacity(10);
+    let mut events: Events = Events::with_capacity(10);
     poll
       .poll(&mut events, Some(StdDuration::from_secs(1)))
       .unwrap();
 
-    let _data2 = udp_listener.get_message();
+    let _data2: Vec<u8> = udp_listener.get_message();
   }
 
   #[test]

--- a/src/network/constant.rs
+++ b/src/network/constant.rs
@@ -8,18 +8,18 @@ const D1: u16 = 10;
 const D2: u16 = 1;
 const D3: u16 = 11;
 
-pub fn spdp_well_known_multicast_port(domain_id: u16) -> u16 {
+pub const fn spdp_well_known_multicast_port(domain_id: u16) -> u16 {
   PB + DG * domain_id + D0
 }
 
-pub fn spdp_well_known_unicast_port(domain_id: u16, participant_id: u16) -> u16 {
+pub const fn spdp_well_known_unicast_port(domain_id: u16, participant_id: u16) -> u16 {
   PB + DG * domain_id + D1 + PG * participant_id
 }
 
-pub fn user_traffic_multicast_port(domain_id: u16) -> u16 {
+pub const fn user_traffic_multicast_port(domain_id: u16) -> u16 {
   PB + DG * domain_id + D2
 }
 
-pub fn user_traffic_unicast_port(domain_id: u16, participant_id: u16) -> u16 {
+pub const fn user_traffic_unicast_port(domain_id: u16, participant_id: u16) -> u16 {
   PB + DG * domain_id + D3 + PG * participant_id
 }

--- a/src/network/udp_listener.rs
+++ b/src/network/udp_listener.rs
@@ -132,7 +132,14 @@ impl UDPListener {
               e, multicast_group, a
             );
           }),
-        IpAddr::V6(_a) => error!("UDPListener::new_multicast() not implemented for IpV6"), // TODO
+
+        IpAddr::V6(addr) => {
+          if let Err(e) = mio_socket.join_multicast_v6(&addr, 0) {
+            warn!(
+              "join_multicast_v6 failed. err: {e}. mcast group: [{multicast_group:?}], addr:[{addr:?}]"
+            );
+          }
+        }
       }
     }
 

--- a/src/network/util.rs
+++ b/src/network/util.rs
@@ -55,3 +55,111 @@ fn get_local_multicast_ip_addrs_inner(interfaces: Vec<NetworkInterface>) -> Vec<
     .filter(|ip| ip.is_ipv4()) // use ipv4 only :(
     .collect::<Vec<_>>()
 }
+
+#[cfg(test)]
+mod tests {
+  use std::{
+    ffi::c_int,
+    net::{Ipv4Addr, Ipv6Addr},
+  };
+
+  use pnet::{
+    datalink::{InterfaceType, NetworkInterface},
+    ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network},
+  };
+
+  /// Mocks the `get_local_multicast_ip_addrs` function.
+  #[test]
+  fn test_get_local_multicast_ip_addrs() {
+    let eth0 = interface(
+      "eth0",
+      1,
+      &[
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(192, 168, 0, 137), 24).unwrap()),
+        IpNetwork::V6(
+          Ipv6Network::new(Ipv6Addr::new(0xfd73, 0x40a2, 0x1c3e, 0, 0, 0, 0, 0), 64).unwrap(),
+        ),
+      ],
+      &[pnet_sys::IFF_MULTICAST],
+    );
+
+    let interfaces = vec![loopback(), eth0];
+
+    let ips = super::get_local_multicast_ip_addrs_inner(interfaces);
+
+    // TODO: uncomment if IPv6 becomes supported :(
+    // assert_eq!(ips.len(), 2, "should only contain the non-loopback iface");
+    assert_eq!(ips.len(), 1, "should only contain the non-loopback iface");
+    assert!(ips.contains(&Ipv4Addr::new(192, 168, 0, 137).into()));
+
+    // TODO: uncomment if ipv6
+    // assert!(ips.contains(&Ipv6Addr::new(0xfd73, 0x40a2, 0x1c3e, 0, 0, 0, 0, 0).into()))
+  }
+
+  /// Tries a number of interfaces, none of which support multicast.
+  ///
+  /// This should result in an empty list of IP addresses.
+  #[test]
+  fn no_multicast() {
+    let mut interfaces = Vec::new();
+
+    for index in 0..10 {
+      interfaces.push(interface(
+        &format!("eth{}", index),
+        index,
+        &[IpNetwork::V4(
+          Ipv4Network::new(Ipv4Addr::new(192, 168, 0, rand::random()), 24).unwrap(),
+        )],
+        &[],
+      ));
+    }
+
+    let ips = super::get_local_multicast_ip_addrs_inner(interfaces);
+
+    assert!(
+      ips.is_empty(),
+      "we only want interfaces w/ multicast support"
+    );
+  }
+
+  #[test]
+  fn empty_interfaces() {
+    let ips = super::get_local_multicast_ip_addrs_inner(Vec::new());
+    assert!(
+      ips.is_empty(),
+      "blank iface list should result in empty list of ips"
+    );
+  }
+
+  fn loopback() -> NetworkInterface {
+    NetworkInterface {
+      name: "lo".to_string(),
+      description: "loopback".to_string(),
+      index: 0,
+      mac: None,
+      ips: vec![
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::LOCALHOST, 24).unwrap()),
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::LOCALHOST, 64).unwrap()),
+      ],
+      flags: pnet_sys::IFF_MULTICAST as InterfaceType & pnet_sys::IFF_LOOPBACK as InterfaceType,
+    }
+  }
+
+  fn interface(
+    name: impl AsRef<str>,
+    index: u32,
+    ips: &[IpNetwork],
+    flags: &[c_int],
+  ) -> NetworkInterface {
+    NetworkInterface {
+      name: name.as_ref().into(),
+      description: String::new(),
+      index,
+      mac: None,
+      ips: ips.to_vec(),
+      flags: flags
+        .iter()
+        .fold(0, |acc, &flag| acc | flag as InterfaceType),
+    }
+  }
+}


### PR DESCRIPTION
Previously, the `rustdds::util::get_local_multicast_ip_addrs` function didn't account for whether an interface had the multicasting flag. 

This PR adds the `pnet` crate as a dependency to handle that properly. :D

## Other changes

I also fixed the crate's known-flaky tests. The first batch were from the `discovery` module, and the failures were just port misalignments. The other failures stemmed from incorrect handling of the internal `mio::net::UdpSocket` - it was set to be async, but the test functions to read weren't accounting for that.

If you'd like those in another PR, please let me know!

(I license all changes included in this patch set under the Apache License, version 2.0.)