### PR TITLE
Add discovered_readers()/discovered_writers() snapshot accessors

### DIFF
--- a/src/dds/participant.rs
+++ b/src/dds/participant.rs
@@ -35,7 +35,7 @@ use crate::{
   discovery::{
     discovery::{Discovery, DiscoveryCommand},
     discovery_db::DiscoveryDB,
-    sedp_messages::DiscoveredTopicData,
+    sedp_messages::{DiscoveredReaderData, DiscoveredTopicData, DiscoveredWriterData},
   },
   network::{constant::*, udp_listener::UDPListener},
   rtps::{
@@ -534,6 +534,50 @@ impl DomainParticipant {
     self.dpi.lock().unwrap().discovered_topics()
   }
 
+  /// Gets a snapshot of all Readers discovered over the DDS network.
+  ///
+  /// The `DomainParticipantStatusListener` reports Reader discovery as a live
+  /// stream of events, so a listener that attaches late or drains slowly can
+  /// miss some of them. This returns the full current set of discovered
+  /// Readers from the internal discovery database instead.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// # use rustdds::DomainParticipant;
+  ///
+  /// let domain_participant = DomainParticipant::new(0).unwrap();
+  /// let discovered_readers = domain_participant.discovered_readers();
+  /// for dreader in discovered_readers.iter() {
+  ///   // do something
+  /// }
+  /// ```
+  pub fn discovered_readers(&self) -> Vec<DiscoveredReaderData> {
+    self.dpi.lock().unwrap().discovered_readers()
+  }
+
+  /// Gets a snapshot of all Writers discovered over the DDS network.
+  ///
+  /// The `DomainParticipantStatusListener` reports Writer discovery as a live
+  /// stream of events, so a listener that attaches late or drains slowly can
+  /// miss some of them. This returns the full current set of discovered
+  /// Writers from the internal discovery database instead.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// # use rustdds::DomainParticipant;
+  ///
+  /// let domain_participant = DomainParticipant::new(0).unwrap();
+  /// let discovered_writers = domain_participant.discovered_writers();
+  /// for dwriter in discovered_writers.iter() {
+  ///   // do something
+  /// }
+  /// ```
+  pub fn discovered_writers(&self) -> Vec<DiscoveredWriterData> {
+    self.dpi.lock().unwrap().discovered_writers()
+  }
+
   /// Manually asserts liveliness, affecting all writers with
   /// LIVELINESS QoS of MANUAL_BY_PARTICIPANT created by
   /// this particular participant.
@@ -950,6 +994,14 @@ impl DomainParticipantDisc {
 
   pub fn discovered_topics(&self) -> Vec<DiscoveredTopicData> {
     self.dpi.discovered_topics()
+  }
+
+  pub fn discovered_readers(&self) -> Vec<DiscoveredReaderData> {
+    self.dpi.discovered_readers()
+  }
+
+  pub fn discovered_writers(&self) -> Vec<DiscoveredWriterData> {
+    self.dpi.discovered_writers()
   }
 
   pub(crate) fn dds_cache(&self) -> Arc<RwLock<DDSCache>> {
@@ -1553,6 +1605,23 @@ impl DomainParticipantInner {
 
     db.all_user_topics().cloned().collect()
   }
+
+  pub fn discovered_readers(&self) -> Vec<DiscoveredReaderData> {
+    let db = self.discovery_db.read().unwrap_or_else(|e| {
+      panic!("RustDDS internal bug: DiscoveryDB is poisoned after a prior panic: {e:?}")
+    });
+
+    db.get_all_external_topic_readers().cloned().collect()
+  }
+
+  pub fn discovered_writers(&self) -> Vec<DiscoveredWriterData> {
+    let db = self.discovery_db.read().unwrap_or_else(|e| {
+      panic!("RustDDS internal bug: DiscoveryDB is poisoned after a prior panic: {e:?}")
+    });
+
+    db.get_all_external_topic_writers().cloned().collect()
+  }
+
   pub(crate) fn status_channel_receiver(
     &self,
   ) -> &StatusChannelReceiver<DomainParticipantStatusEvent> {

--- a/src/discovery/discovery_db.rs
+++ b/src/discovery/discovery_db.rs
@@ -690,6 +690,14 @@ impl DiscoveryDB {
     self.local_topic_writers.values()
   }
 
+  pub fn get_all_external_topic_readers(&self) -> impl Iterator<Item = &DiscoveredReaderData> {
+    self.external_topic_readers.values()
+  }
+
+  pub fn get_all_external_topic_writers(&self) -> impl Iterator<Item = &DiscoveredWriterData> {
+    self.external_topic_writers.values()
+  }
+
   // Note:
   // If multiple participants announce the same topic, this will
   // return duplicates, one per announcing participant.
@@ -971,6 +979,73 @@ mod tests {
     discovery_db.update_subscription(&dreader3);
 
     // TODO: there might be a need for different scenarios
+  }
+
+  #[test]
+  fn discdb_external_endpoint_snapshots() {
+    let (discovery_db_event_sender, _discovery_db_event_receiver) =
+      mio_channel::sync_channel::<()>(4);
+    let (status_sender, _status_receiver) = sync_status_channel(16).unwrap();
+
+    let mut discovery_db = DiscoveryDB::new(
+      GUID::new_participant_guid(),
+      discovery_db_event_sender,
+      status_sender,
+    );
+
+    // Nothing discovered yet.
+    assert_eq!(discovery_db.get_all_external_topic_readers().count(), 0);
+    assert_eq!(discovery_db.get_all_external_topic_writers().count(), 0);
+
+    // Discover one external Reader via SEDP subscription data.
+    let reader = reader_proxy_data().unwrap();
+    let reader_sub = subscription_builtin_topic_data().unwrap();
+    let dreader = DiscoveredReaderData {
+      reader_proxy: reader,
+      subscription_topic_data: reader_sub,
+      content_filter: None,
+      user_data: Vec::new(),
+    };
+    discovery_db.update_subscription(&dreader);
+
+    // Discover one external Writer via SEDP publication data.
+    let domain_participant = DomainParticipant::new(0).expect("Failed to create participant");
+    let topic = domain_participant
+      .create_topic(
+        "Foobar".to_string(),
+        "RandomData".to_string(),
+        &QosPolicies::qos_none(),
+        TopicKind::WithKey,
+      )
+      .unwrap();
+    let publisher = domain_participant
+      .create_publisher(&QosPolicies::qos_none())
+      .unwrap();
+    let dw = publisher
+      .create_datawriter::<RandomData, CDRSerializerAdapter<RandomData, LittleEndian>>(&topic, None)
+      .unwrap();
+    let writer_data = DiscoveredWriterData::new(&dw, &topic, &domain_participant, None);
+    discovery_db.update_publication(&writer_data);
+
+    // Both accessors return the discovered endpoints as a snapshot.
+    let readers = discovery_db
+      .get_all_external_topic_readers()
+      .cloned()
+      .collect::<Vec<_>>();
+    let writers = discovery_db
+      .get_all_external_topic_writers()
+      .cloned()
+      .collect::<Vec<_>>();
+    assert_eq!(readers.len(), 1);
+    assert_eq!(writers.len(), 1);
+    assert_eq!(
+      readers[0].reader_proxy.remote_reader_guid,
+      dreader.reader_proxy.remote_reader_guid
+    );
+    assert_eq!(
+      writers[0].writer_proxy.remote_writer_guid,
+      writer_data.writer_proxy.remote_writer_guid
+    );
   }
 
   #[test]


### PR DESCRIPTION
## What

Adds `discovered_readers()` / `discovered_writers()` snapshot accessors, mirroring the existing `discovered_topics()` at all three delegation layers (`DomainParticipant` → `DomainParticipantDisc` → `DomainParticipantInner`), backed by two new `DiscoveryDB` getters over the `external_topic_readers` / `external_topic_writers` maps.

## Why

The status-event channel can lose discovery events for a consumer that attaches late or drains slowly — but `DiscoveryDB` retains the full current state. A snapshot accessor lets applications harvest remote endpoint discovery loss-free at any point, instead of reconstructing state from an event stream they may have partially missed.

Our concrete use case: ROS 2 nodes publish REP-2011 type hashes in endpoint `USER_DATA` QoS. Since `user_data` is carried on `DiscoveredReaderData` / `DiscoveredWriterData`, these accessors expose remote endpoints' `USER_DATA` (and the rest of the endpoint QoS) directly from the DB snapshot — we use this to drive `type_description_interfaces` lookups against live robots.

## Notes

- Additive only — no existing signatures or behavior changed.
- Snapshot semantics (cloned `Vec`), same shape as `discovered_topics()`.
- Includes an in-module `DiscoveryDB` test + doctests.

Happy to adjust naming/placement to whatever fits the project's conventions.
