### PR TITLE
fix: retain cache changes that collide on reception instant

### DIFF
--- a/src/dds/qos.rs
+++ b/src/dds/qos.rs
@@ -233,6 +233,89 @@ pub struct QosPolicies {
   pub(crate) property: Option<policy::Property>,
 }
 
+/// Default QoS policy values from DDS Specification v1.4 Section 2.2.3
+/// (tables "DDS QosPolicies").
+///
+/// RTPS discovery (SEDP) permits a participant to omit a QoS parameter when it
+/// equals the endpoint's default value; a receiver must then assume that
+/// default (e.g. Fast DDS 3.x omits such parameters). The defaults differ
+/// between DataWriters and DataReaders — most notably Reliability: writers
+/// default to Reliable, readers to BestEffort.
+pub mod spec_qos_defaults {
+  use super::{policy, QosPolicies};
+  use crate::structure::duration::Duration;
+
+  /// Effective QoS of a DataWriter that does not specify a policy.
+  ///
+  /// History and resource-limits stay `None`: they are not part of SEDP
+  /// discovery data (RTPS spec 2.5, Figure 8.30). Time-based filter is a
+  /// DataReader policy and stays `None` here.
+  pub fn data_writer() -> QosPolicies {
+    QosPolicies {
+      durability: Some(policy::Durability::Volatile),
+      presentation: Some(policy::Presentation {
+        access_scope: policy::PresentationAccessScope::Instance,
+        coherent_access: false,
+        ordered_access: false,
+      }),
+      deadline: Some(policy::Deadline(Duration::INFINITE)),
+      latency_budget: Some(policy::LatencyBudget {
+        duration: Duration::ZERO,
+      }),
+      ownership: Some(policy::Ownership::Shared),
+      liveliness: Some(policy::Liveliness::Automatic {
+        lease_duration: Duration::INFINITE,
+      }),
+      time_based_filter: None,
+      reliability: Some(policy::Reliability::Reliable {
+        max_blocking_time: Duration::from_millis(100),
+      }),
+      destination_order: Some(policy::DestinationOrder::ByReceptionTimestamp),
+      history: None,
+      resource_limits: None,
+      lifespan: Some(policy::Lifespan {
+        duration: Duration::INFINITE,
+      }),
+      #[cfg(feature = "security")]
+      property: None,
+    }
+  }
+
+  /// Effective QoS of a DataReader that does not specify a policy.
+  ///
+  /// History and resource-limits stay `None`: they are not part of SEDP
+  /// discovery data (RTPS spec 2.5, Figure 8.30). Lifespan is a DataWriter
+  /// policy and stays `None` here.
+  pub fn data_reader() -> QosPolicies {
+    QosPolicies {
+      durability: Some(policy::Durability::Volatile),
+      presentation: Some(policy::Presentation {
+        access_scope: policy::PresentationAccessScope::Instance,
+        coherent_access: false,
+        ordered_access: false,
+      }),
+      deadline: Some(policy::Deadline(Duration::INFINITE)),
+      latency_budget: Some(policy::LatencyBudget {
+        duration: Duration::ZERO,
+      }),
+      ownership: Some(policy::Ownership::Shared),
+      liveliness: Some(policy::Liveliness::Automatic {
+        lease_duration: Duration::INFINITE,
+      }),
+      time_based_filter: Some(policy::TimeBasedFilter {
+        minimum_separation: Duration::ZERO,
+      }),
+      reliability: Some(policy::Reliability::BestEffort),
+      destination_order: Some(policy::DestinationOrder::ByReceptionTimestamp),
+      history: None,
+      resource_limits: None,
+      lifespan: None,
+      #[cfg(feature = "security")]
+      property: None,
+    }
+  }
+}
+
 impl QosPolicies {
   // TODO: rename this to "none", as this is already member of QosPolicies, so
   // context in implied

--- a/src/discovery/discovery.rs
+++ b/src/discovery/discovery.rs
@@ -1179,6 +1179,9 @@ impl Discovery {
               guid: reader_key,
               reason: LostReason::Disposed,
             });
+            // Propagate the dispose into our local SEDP cache so participants
+            // discovering us later also see the endpoint disappear.
+            self.send_endpoint_dispose_message(reader_key);
           }
         }
       }
@@ -1243,6 +1246,9 @@ impl Discovery {
               guid: writer_key,
               reason: LostReason::Disposed,
             });
+            // Propagate the dispose into our local SEDP cache so participants
+            // discovering us later also see the endpoint disappear.
+            self.send_endpoint_dispose_message(writer_key);
 
             debug!("Disposed Writer {writer_key:?}");
           }

--- a/src/discovery/discovery_db.rs
+++ b/src/discovery/discovery_db.rs
@@ -225,29 +225,19 @@ impl DiscoveryDB {
   // active_disposal means that we received a discovery message announcing the
   // disposal of the participant. active_disposal=false means that the
   // participant timed out.
-  pub fn remove_participant(&mut self, guid_prefix: GuidPrefix, active_disposal: bool) {
+  //
+  // In both cases, remove the participant's endpoints so that Lost events fire
+  // and consumers see the endpoints disappear. If the participant comes back,
+  // SEDP rediscovery will re-add its endpoints.
+  pub fn remove_participant(&mut self, guid_prefix: GuidPrefix, _active_disposal: bool) {
     info!("removing participant {guid_prefix:?}");
     self.participant_proxies.remove(&guid_prefix);
     self.participant_last_life_signs.remove(&guid_prefix);
     #[cfg(feature = "security")]
     self.authentication_statuses.remove(&guid_prefix);
 
-    if active_disposal {
-      self.remove_topic_reader_with_prefix(guid_prefix);
-      self.remove_topic_writer_with_prefix(guid_prefix);
-    } else {
-      // move to attic
-      move_by_guid_prefix(
-        guid_prefix,
-        &mut self.external_topic_readers,
-        &mut self.external_topic_readers_attic,
-      );
-      move_by_guid_prefix(
-        guid_prefix,
-        &mut self.external_topic_writers,
-        &mut self.external_topic_writers_attic,
-      );
-    }
+    self.remove_topic_reader_with_prefix(guid_prefix);
+    self.remove_topic_writer_with_prefix(guid_prefix);
   }
 
   pub fn find_participant_proxy(

--- a/src/discovery/sedp_messages.rs
+++ b/src/discovery/sedp_messages.rs
@@ -17,7 +17,7 @@ use crate::{
         Deadline, DestinationOrder, Durability, History, LatencyBudget, Lifespan, Liveliness,
         Ownership, Presentation, Reliability, ResourceLimits, TimeBasedFilter,
       },
-      HasQoSPolicy, QosPolicies,
+      spec_qos_defaults, HasQoSPolicy, QosPolicies,
     },
     topic::{Topic, TopicDescription},
     with_key::datawriter::DataWriter,
@@ -260,7 +260,10 @@ impl SubscriptionBuiltinTopicData {
     // resource_limits does not exist
   }
 
-  pub fn qos(&self) -> QosPolicies {
+  /// QoS exactly as present on this struct, `None` for parameters that were
+  /// not set or received. Used for serialization so that announcements carry
+  /// only explicitly-set policies.
+  fn wire_qos(&self) -> QosPolicies {
     QosPolicies {
       durability: self.durability,
       presentation: self.presentation,
@@ -274,6 +277,32 @@ impl SubscriptionBuiltinTopicData {
       history: None, // SubscriptionBuiltinTopicData does not contain History QoS
       resource_limits: None, // nor Resource Limits, see Figure 8.30 in RTPS spec 2.5
       lifespan: self.lifespan,
+      #[cfg(feature = "security")]
+      property: None, // TODO: no property QoS?
+    }
+  }
+
+  /// Effective QoS of the discovered reader.
+  ///
+  /// QoS parameters omitted from the received SEDP data resolve to the DDS
+  /// spec defaults for a DataReader (RTPS: an absent parameter means its
+  /// default value; Fast DDS 3.x omits default-valued parameters). The struct
+  /// fields keep only what was actually received.
+  pub fn qos(&self) -> QosPolicies {
+    let defaults = spec_qos_defaults::data_reader();
+    QosPolicies {
+      durability: self.durability.or(defaults.durability),
+      presentation: self.presentation.or(defaults.presentation),
+      deadline: self.deadline.or(defaults.deadline),
+      latency_budget: self.latency_budget.or(defaults.latency_budget),
+      ownership: self.ownership.or(defaults.ownership),
+      liveliness: self.liveliness.or(defaults.liveliness),
+      time_based_filter: self.time_based_filter.or(defaults.time_based_filter),
+      reliability: self.reliability.or(defaults.reliability),
+      destination_order: self.destination_order.or(defaults.destination_order),
+      history: None, // SubscriptionBuiltinTopicData does not contain History QoS
+      resource_limits: None, // nor Resource Limits, see Figure 8.30 in RTPS spec 2.5
+      lifespan: self.lifespan.or(defaults.lifespan),
 
       #[cfg(feature = "security")]
       property: None, // TODO: no property QoS?
@@ -488,7 +517,7 @@ impl ParameterListable for DiscoveredReaderData {
     } = self;
 
     let mut pl = ParameterList::new();
-    let qos = sbtd.qos();
+    let qos = sbtd.wire_qos();
 
     let ctx = pl_cdr_rep_id_to_speedy(encoding)?;
 
@@ -704,7 +733,10 @@ impl PublicationBuiltinTopicData {
     self.presentation = qos.presentation;
   }
 
-  pub fn qos(&self) -> QosPolicies {
+  /// QoS exactly as present on this struct, `None` for parameters that were
+  /// not set or received. Used for serialization so that announcements carry
+  /// only explicitly-set policies.
+  fn wire_qos(&self) -> QosPolicies {
     QosPolicies {
       durability: self.durability,
       presentation: self.presentation,
@@ -718,6 +750,33 @@ impl PublicationBuiltinTopicData {
       history: None,         // PublicationBuiltinTopicData does not contain History QoS
       resource_limits: None, // nor Resource Limits, see Figure 8.30 in RTPS spec 2.5
       lifespan: self.lifespan,
+      #[cfg(feature = "security")]
+      property: None, // TODO: no property Qos?
+    }
+  }
+
+  /// Effective QoS of the discovered writer.
+  ///
+  /// QoS parameters omitted from the received SEDP data resolve to the DDS
+  /// spec defaults for a DataWriter (RTPS: an absent parameter means its
+  /// default value; Fast DDS 3.x omits default-valued parameters). Note the
+  /// writer default for Reliability is Reliable, unlike DataReaders. The
+  /// struct fields keep only what was actually received.
+  pub fn qos(&self) -> QosPolicies {
+    let defaults = spec_qos_defaults::data_writer();
+    QosPolicies {
+      durability: self.durability.or(defaults.durability),
+      presentation: self.presentation.or(defaults.presentation),
+      deadline: self.deadline.or(defaults.deadline),
+      latency_budget: self.latency_budget.or(defaults.latency_budget),
+      ownership: self.ownership.or(defaults.ownership),
+      liveliness: self.liveliness.or(defaults.liveliness),
+      time_based_filter: self.time_based_filter.or(defaults.time_based_filter),
+      reliability: self.reliability.or(defaults.reliability),
+      destination_order: self.destination_order.or(defaults.destination_order),
+      history: None,         // PublicationBuiltinTopicData does not contain History QoS
+      resource_limits: None, // nor Resource Limits, see Figure 8.30 in RTPS spec 2.5
+      lifespan: self.lifespan.or(defaults.lifespan),
       #[cfg(feature = "security")]
       property: None, // TODO: no property Qos?
     }
@@ -941,7 +1000,7 @@ impl ParameterListable for DiscoveredWriterData {
     } = self;
 
     let mut pl = ParameterList::new();
-    let qos = pbtd.qos();
+    let qos = pbtd.wire_qos();
 
     let ctx = pl_cdr_rep_id_to_speedy(encoding)?;
 
@@ -1415,6 +1474,121 @@ mod tests {
 
     let msg = Message::read_from_buffer(&raw_data).unwrap();
     info!("{msg:?}");
+  }
+
+  #[test]
+  fn qos_spec_defaults_for_omitted_writer_params() {
+    use crate::structure::duration::Duration;
+
+    let pub_data = PublicationBuiltinTopicData::new(
+      GUID::GUID_UNKNOWN,
+      None,
+      "Square".to_string(),
+      "ShapeType".to_string(),
+      None,
+    );
+    // Struct stays wire-faithful: nothing received, nothing stored.
+    assert_eq!(pub_data.reliability, None);
+    assert_eq!(pub_data.durability, None);
+
+    // Effective QoS resolves to the DataWriter spec defaults.
+    let qos = pub_data.qos();
+    assert_eq!(
+      qos.reliability(),
+      Some(Reliability::Reliable {
+        max_blocking_time: Duration::from_millis(100),
+      })
+    );
+    assert_eq!(qos.durability(), Some(Durability::Volatile));
+    assert_eq!(qos.deadline(), Some(Deadline(Duration::INFINITE)));
+    assert_eq!(
+      qos.liveliness(),
+      Some(Liveliness::Automatic {
+        lease_duration: Duration::INFINITE,
+      })
+    );
+    assert_eq!(
+      qos.lifespan(),
+      Some(Lifespan {
+        duration: Duration::INFINITE,
+      })
+    );
+  }
+
+  #[test]
+  fn qos_spec_defaults_for_omitted_reader_params() {
+    let sub_data = SubscriptionBuiltinTopicData::new(
+      GUID::GUID_UNKNOWN,
+      None,
+      "Square".to_string(),
+      "ShapeType".to_string(),
+      &QosPolicies::qos_none(),
+      None,
+    );
+    assert_eq!(sub_data.reliability, None);
+
+    // DataReader reliability default is BestEffort — asymmetric to DataWriters.
+    let qos = sub_data.qos();
+    assert_eq!(qos.reliability(), Some(Reliability::BestEffort));
+    assert_eq!(qos.durability(), Some(Durability::Volatile));
+    assert_eq!(qos.lifespan(), None);
+  }
+
+  #[test]
+  fn qos_explicit_wire_values_preserved() {
+    let mut pub_data = PublicationBuiltinTopicData::new(
+      GUID::GUID_UNKNOWN,
+      None,
+      "Square".to_string(),
+      "ShapeType".to_string(),
+      None,
+    );
+    pub_data.reliability = Some(Reliability::BestEffort);
+    pub_data.durability = Some(Durability::TransientLocal);
+
+    let qos = pub_data.qos();
+    assert_eq!(qos.reliability(), Some(Reliability::BestEffort));
+    assert_eq!(qos.durability(), Some(Durability::TransientLocal));
+  }
+
+  #[test]
+  fn omitted_qos_params_roundtrip_as_none_but_qos_fills_defaults() {
+    // Simulates Fast DDS 3.x behavior: QoS parameters equal to the endpoint
+    // defaults are omitted from the serialized SEDP data entirely.
+    let mut writer_proxy = writer_proxy_data().unwrap();
+    let pub_data = PublicationBuiltinTopicData::new(
+      writer_proxy.remote_writer_guid,
+      None,
+      "Square".to_string(),
+      "ShapeType".to_string(),
+      None,
+    );
+    writer_proxy.remote_writer_guid = pub_data.key;
+
+    let dwd = DiscoveredWriterData {
+      last_updated: Instant::now(),
+      writer_proxy,
+      publication_topic_data: pub_data,
+      user_data: Vec::new(),
+    };
+
+    let sdata = dwd
+      .to_pl_cdr_bytes(RepresentationIdentifier::PL_CDR_LE)
+      .unwrap();
+    let dwd2: DiscoveredWriterData =
+      PlCdrDeserializerAdapter::from_bytes(&sdata, RepresentationIdentifier::PL_CDR_LE).unwrap();
+
+    // Wire fidelity: omitted parameters parse back as None on the struct.
+    assert_eq!(dwd2.publication_topic_data.reliability, None);
+    assert_eq!(dwd2.publication_topic_data.durability, None);
+
+    // Effective QoS applies the DataWriter spec defaults.
+    let qos = dwd2.publication_topic_data.qos();
+    assert!(matches!(
+      qos.reliability(),
+      Some(Reliability::Reliable { .. })
+    ));
+    assert_eq!(qos.durability(), Some(Durability::Volatile));
   }
 
   #[test]

--- a/src/structure/dds_cache.rs
+++ b/src/structure/dds_cache.rs
@@ -253,17 +253,25 @@ impl TopicCache {
       None
     } else {
       // This is a new (to us) SequenceNumber, this is the default processing path.
-      self.insert_sn(*instant, &cache_change);
-      self
-        .changes
-        .insert(*instant, cache_change)
-        .inspect(|old_cc| {
-          // If this happens, cache changes were created at exactly same instant.
-          // This is bad, since we are using instants as keys and assume that they
-          // are unique.
-          error!("DDSHistoryCache already contained element with key {instant:?} !!!");
-          self.remove_sn(old_cc);
-        })
+      //
+      // Reception instants are not guaranteed unique: several samples decoded
+      // within the same clock tick (e.g. a discovery burst arriving in one
+      // datagram) would collide on the map key, and evicting the incumbent
+      // would permanently lose a change the reliability protocol has already
+      // acknowledged. Probe forward to the next vacant tick instead; the
+      // sub-nanosecond skew preserves ordering.
+      let mut key = *instant;
+      while self.changes.contains_key(&key) {
+        key = Timestamp::from_ticks(key.to_ticks() + 1);
+      }
+      if key != *instant {
+        debug!(
+          "add_change: bumped colliding instant {:?} to {:?} topic={:?}",
+          instant, key, self.topic_name
+        );
+      }
+      self.insert_sn(key, &cache_change);
+      self.changes.insert(key, cache_change)
     }
   }
 
@@ -577,6 +585,43 @@ mod tests {
         )
         .count(),
       3
+    );
+  }
+
+  #[test]
+  fn same_instant_changes_are_all_retained() {
+    let dds_cache = Arc::new(RwLock::new(DDSCache::new()));
+    let qos = QosPolicies::qos_none();
+    let topic_cache_handle = dds_cache.write().unwrap().add_new_topic(
+      String::from("BurstTopic"),
+      TypeDesc::new("BurstType".to_string()),
+      &qos,
+    );
+
+    // Samples decoded within the same clock tick share a reception instant,
+    // as happens when a discovery burst arrives in one datagram. None of
+    // them may be lost to key collisions.
+    let instant = crate::Timestamp::now();
+    for sn in 1..=8 {
+      let change = CacheChange::new(
+        GUID::GUID_UNKNOWN,
+        SequenceNumber::new(sn),
+        WriteOptions::default(),
+        DDSData::new(SerializedPayload::default()),
+      );
+      topic_cache_handle.lock().unwrap().add_change(&instant, change);
+    }
+
+    assert_eq!(
+      topic_cache_handle
+        .lock()
+        .unwrap()
+        .get_changes_in_range_best_effort(
+          instant - crate::Duration::from_secs(1),
+          crate::Timestamp::now() + crate::Duration::from_secs(1)
+        )
+        .count(),
+      8
     );
   }
 }


### PR DESCRIPTION
## Summary

`TopicCache::add_change_internal` keys the history cache by reception `Timestamp` and assumes instants are unique. When several samples are decoded within the same clock tick — routinely the case for an SEDP burst arriving in one datagram, e.g. a rosbag2 player announcing ~46 writers at once — the map insert collides and evicts the incumbent change. Because the reliability protocol has already acknowledged that change, it is never retransmitted: the announcement is permanently lost.

Observed impact through iris/rewire: attaching a subscriber to an already-running graph lost a random ~10% of topics per run (`DDSHistoryCache already contained element` followed by `DDSCache insert failed`), including transient-local history. With this fix, 3/3 repro runs against a 46-topic bag achieve complete topic coverage with zero cache errors.

The fix probes forward to the next vacant tick before inserting. One tick is 2^-32 s, so the skew is sub-nanosecond and ordering across distinct real instants is preserved. The sequence-number index is written with the bumped key so `find_by_sn` stays consistent.

## Test

`same_instant_changes_are_all_retained` inserts eight changes at one instant and asserts all are retrievable. Full lib suite passes (637 tests).